### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler # caching to speed up dependency installation
 rvm:
-- 2.4.1
+- 2.5.0
 addons:
   apt:
     packages:


### PR DESCRIPTION
2.4.1 was being incompatible with couple of dependencies as well as 2.4.4, so updated to 2.5.0
Fixed Issue https://github.com/githubtraining/continuous-integration-travis-demo/issues/7